### PR TITLE
Fix unusually long hero

### DIFF
--- a/pages/charcuterie.js
+++ b/pages/charcuterie.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Head from 'next/head';
 import Carousel from '../components/Carousel';
 import NavBar from '../components/NavBar';
+import Hero from '../components/Hero';
 import Modal from '../components/Modal';
 import HackathonCard from '../components/HackathonCard';
 import Button from '../components/Button';
@@ -22,6 +23,7 @@ export default function Charcuterie() {
         <title>Charcuterie | nwPlus</title>
       </Head>
       <Background>
+        <Hero />
         <ContentContainer>
           <LargeTitle>charcuterie 😋</LargeTitle>
           <Body>Just a place where we put things</Body>


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->

## Description
Fixed the usually long hero section by removing `min-height: 100vh` from hero container (regression from #64)

## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->