### PR TITLE
Add missing sections, connect and refactor nav bar

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,28 @@
+{
+  "env": {
+    "development": {
+      "plugins": [
+        [
+          "babel-plugin-styled-components",
+          { "ssr": true, "displayName": true, "preprocess": false }
+        ]
+      ],
+      "presets": ["next/babel"]
+    },
+    "production": {
+      "plugins": [
+        [
+          "babel-plugin-styled-components",
+          { "ssr": true, "displayName": true, "preprocess": false }
+        ]
+      ],
+      "presets": ["next/babel"]
+    }
+  },
+  "plugins": [
+    [
+      "babel-plugin-styled-components",
+      { "ssr": true, "displayName": true, "preprocess": false }
+    ]
+  ]
+}

--- a/components/ContentContainer.js
+++ b/components/ContentContainer.js
@@ -3,10 +3,11 @@ import styled from 'styled-components';
 export const Wrapper = styled.div`
   width: 100%;
   max-width: 1600px;
-  margin: 0 auto;
+  margin: ${(p) => p.margin ? p.margin : '0 auto'};
   ${(p) => p.theme.mediaQueries.mobile} {
     max-width: 640px;
     min-width: 320px;
+    margin: ${(p) => p.margin ? p.margin : '0 auto'};
   }
 `;
 
@@ -21,8 +22,8 @@ export const Content = styled.div`
   }
 `;
 
-export const ContentContainer = ({ children }) => (
-  <Wrapper>
+export const ContentContainer = ({ children, id, margin }) => (
+  <Wrapper id={id} margin={margin}>
     <Content>{children}</Content>
   </Wrapper>
 );

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -167,12 +167,38 @@ const DropDownContentContainer = styled.div`
   gap: 24px;
 `;
 
-const MenuList = ({ setShowDropdown = () => null }) => {
+const MenuItem = ({ name, href, isAnchor}) => {
+  const [anchorTarget, setAnchorTarget] = useState(null);
+  
+  useEffect(() => {
+    if (isAnchor) {
+      setAnchorTarget(document.getElementById(href));
+    }
+  }, [href]);
+
+  const handleClick = (event) => {
+    if (isAnchor && anchorTarget) {
+      event.preventDefault();
+      anchorTarget.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }
+
+  return (
+    <LinkText
+      href={href}
+      onClick={handleClick}
+    >
+      {name}
+    </LinkText>
+  )
+}
+
+const MenuList = () => {
   return  (<>
-    <LinkText href="#" onClick={() => setShowDropdown()}>About Us</LinkText>
-    <LinkText href="#" onClick={() => setShowDropdown()}>Hackathons</LinkText>
-    <LinkText href="#" onClick={() => setShowDropdown()}>Resources</LinkText>
-    <LinkText href="#" onClick={() => setShowDropdown()}>FAQ</LinkText>
+    <MenuItem name="About Us" href="#about" isAnchor />
+    <MenuItem name="Hackathons" href="#hackathons" isAnchor />
+    <MenuItem name="Resources" href="#resources" isAnchor />
+    <MenuItem name="FAQ" href="#faq" isAnchor />
   </>);
 }
 

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -210,11 +210,11 @@ const NavBar = () => {
     const applicationInfo = await fireDb.getCollection('www', 'Applications');
     setapplicationInfo(applicationInfo[0]);
     const liveportalInfo = await fireDb.getCollection('www', 'LivePortalLink');
-    setLivePortalLink(liveportalInfo[0].url);
+    setLivePortalLink(liveportalInfo[0]?.url);
   }
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll());
+    window.addEventListener('scroll', handleScroll);
     window.addEventListener('resize', handleResize);
     getApplicationData();
     return () => {

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -3,38 +3,26 @@ import { useState, useEffect } from 'react';
 
 import { SCREEN_BREAKPOINTS } from '../pages/_app';
 import fireDb from '../utilities/firebase';
-
-import { Content, Wrapper} from './ContentContainer';
-
-const StyledWrapper = styled(Wrapper)`
+ 
+const NavBarContainer = styled.nav`
   position: fixed;
   top: 0;
+  left: 50%;
+  transform: translate(-50%, 0);
   z-index: 3;
-  max-width: unset;
-  display: flex;
-  justify-content: center;
-`;
-
-const StyledWrapperDark = styled(StyledWrapper)`
-  background-color: ${(p) => p.theme.colors.background};
-`;
-
-const StyledContent = styled(Content)`
   max-width: 1600px;
-`;
- 
-const NavBarContainer = styled.div`
   width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
   visibility: ${p => p.visibility};
   opacity: ${p => p.opacity};
-  transition: 0.5s ease-in-out;
-  margin: 25px 0;
+  ${p => p.darkBg ? `background-color: ${p.theme.colors.background};` : ''}
+  transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
+  padding: 48px 40px;
 
   ${(p) => p.theme.mediaQueries.mobile} {
-    margin: 10px 0;
+    padding: 24px 40px;
   }
 `;
 
@@ -161,13 +149,19 @@ const HamburgerMenu = styled.img`
 const Cross = HamburgerMenu;
 
 const DropDownContentContainer = styled.div`
-  padding: 20px 0 27px 0;
+  position: fixed;
+  top: 78px;
+  z-index: 3;
+  padding: 20px 40px 27px;
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: 24px;
+  width: 100%;
+  background-color: ${p => p.theme.colors.background};
 `;
 
-const MenuItem = ({ name, href, isAnchor}) => {
+const MenuItem = ({ name, href, isAnchor }) => {
   const [anchorTarget, setAnchorTarget] = useState(null);
   
   useEffect(() => {
@@ -194,19 +188,20 @@ const MenuItem = ({ name, href, isAnchor}) => {
 }
 
 const MenuList = () => {
-  return  (<>
-    <MenuItem name="About Us" href="#about" isAnchor />
-    <MenuItem name="Hackathons" href="#hackathons" isAnchor />
-    <MenuItem name="Resources" href="#resources" isAnchor />
-    <MenuItem name="FAQ" href="#faq" isAnchor />
-  </>);
+  return (
+    <>
+      <MenuItem name="About Us" href="#about" isAnchor />
+      <MenuItem name="Hackathons" href="#hackathons" isAnchor />
+      <MenuItem name="Resources" href="#resources" isAnchor />
+      <MenuItem name="FAQ" href="#faq" isAnchor />
+    </>
+  );
 }
 
 const NavBar = () => {
   const [showDropdown, setShowDropdown] = useState(false);
   const [visibility, setVisibility] = useState('visible');
   const [opacity, setOpacity] = useState('1');
-  const [lastScroll, setLastScroll] = useState(0);
 
   const [applicationInfo, setapplicationInfo] = useState(null);
   const [livePortalLink, setLivePortalLink] = useState('');
@@ -219,7 +214,7 @@ const NavBar = () => {
   }
 
   useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll());
     window.addEventListener('resize', handleResize);
     getApplicationData();
     return () => {
@@ -235,60 +230,57 @@ const NavBar = () => {
   }
 
   const handleScroll = () => {
-    const scroll = window.pageYOffset || document.documentElement.scrollTop;
-    if (scroll <= 0) {
-      setVisibility('visible');
-      setOpacity('1');
-    } else if (scroll > lastScroll) {
-      setVisibility('hidden');
-      setOpacity('0');
-    } else {
-      setVisibility('visible');
-      setOpacity('1');
+    var lastScroll = 0;
+    return () => {
+      const scroll = window.pageYOffset || document.documentElement.scrollTop;
+      if (scroll <= 0) {
+        setVisibility('visible');
+        setOpacity('1');
+      } else if (scroll > lastScroll) {
+        setVisibility('hidden');
+        setOpacity('0');
+      } else {
+        setVisibility('visible');
+        setOpacity('1');
+      }
+      lastScroll = scroll;
     }
-    setLastScroll(scroll);
   }
 
   if (showDropdown) {
-    return (<StyledWrapperDark>
-      <StyledContent>
-        <NavBarContainer>
+    return (
+      <>
+        <NavBarContainer darkBg>
           <NwPlusLogo src="/assets/logos/nwPlus_Logo_2020.svg" alt="nwPlus club logo in white against dark blue background"/>
-          <Cross src="/assets/icons/close_white.svg" alt="dropdown menu icon"
-          onClick={() => setShowDropdown(false)}/>
+          <Cross src="/assets/icons/close_white.svg" alt="dropdown menu icon" onClick={() => setShowDropdown(false)}/>
         </NavBarContainer>
         <DropDownContentContainer>
-          <MenuList setShowDropdown={() => setShowDropdown(false)}/>
+          <MenuList />
           <JoinLink hiring={applicationInfo?.isOpen} hiringLink={applicationInfo?.url} setShowDropdown={() => setShowDropdown(false)}/>
           <a href={livePortalLink} rel="noreferrer noopener" target={livePortalLink !== '#' && "_blank"}>
             <LivePortalButton>Live Portal</LivePortalButton>
           </a>
         </DropDownContentContainer>
-      </StyledContent>
-    </StyledWrapperDark>
+      </>
     );
   }
 
-  return (<StyledWrapper>
-    <StyledContent>
-      <NavBarContainer visibility={visibility} opacity={opacity}>
-        <NavGroupContainer>
-          <NwPlusLogo src="/assets/logos/nwPlus_Logo_2020.svg" alt="nwPlus club logo in white against dark blue background"/>
-          <NavTextContainer>
-            <MenuList/>
-          </NavTextContainer>
-        </NavGroupContainer>
+  return (
+    <NavBarContainer visibility={visibility} opacity={opacity}>
+      <NavGroupContainer>
+        <NwPlusLogo src="/assets/logos/nwPlus_Logo_2020.svg" alt="nwPlus club logo in white against dark blue background"/>
         <NavTextContainer>
-          <JoinLink hiring={applicationInfo?.isOpen} hiringLink={applicationInfo?.url ?? '#'}/>
-          <a href={livePortalLink ?? '#'}>
-            <LivePortalButton>Live Portal</LivePortalButton>
-          </a>
+          <MenuList />
         </NavTextContainer>
-        <HamburgerMenu src="/assets/icons/menu.svg" alt="dropdown menu icon"
-        onClick={() => setShowDropdown(true)}/>
-      </NavBarContainer>
-      </StyledContent>
-    </StyledWrapper>
+      </NavGroupContainer>
+      <NavTextContainer>
+        <JoinLink hiring={applicationInfo?.isOpen} hiringLink={applicationInfo?.url ?? '#'}/>
+        <a href={livePortalLink ?? '#'}>
+          <LivePortalButton>Live Portal</LivePortalButton>
+        </a>
+      </NavTextContainer>
+      <HamburgerMenu src="/assets/icons/menu.svg" alt="dropdown menu icon" onClick={() => setShowDropdown(true)}/>
+    </NavBarContainer>
   )
 }
 

--- a/components/NavBar.js
+++ b/components/NavBar.js
@@ -19,10 +19,10 @@ const NavBarContainer = styled.nav`
   opacity: ${p => p.opacity};
   ${p => p.darkBg ? `background-color: ${p.theme.colors.background};` : ''}
   transition: opacity 0.5s ease-in-out, visibility 0.5s ease-in-out;
-  padding: 48px 40px;
+  padding: 48px 40px 0;
 
   ${(p) => p.theme.mediaQueries.mobile} {
-    padding: 24px 40px;
+    padding: 24px 40px 0;
   }
 `;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,10 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-lottie": "^1.2.3",
-        "styled-components": "^5.1.1"
+        "styled-components": "^5.3.0"
       },
       "devDependencies": {
+        "babel-plugin-styled-components": "^1.13.2",
         "eslint": "^7.32.0",
         "eslint-config-airbnb": "^18.2.1",
         "eslint-config-next": "11.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "react": "17.0.2",
         "react-dom": "17.0.2",
         "react-lottie": "^1.2.3",
-        "styled-components": "^5.3.0"
+        "styled-components": "^5.1.1"
       },
       "devDependencies": {
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,10 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-lottie": "^1.2.3",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.3.0"
   },
   "devDependencies": {
+    "babel-plugin-styled-components": "^1.13.2",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-next": "11.0.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-lottie": "^1.2.3",
-    "styled-components": "^5.3.0"
+    "styled-components": "^5.1.1"
   },
   "devDependencies": {
     "eslint": "^7.32.0",

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,6 +10,8 @@ import Faq from '../components/Faq'
 import Footer from '../components/Footer'
 import Hackathons from '../components/Hackathons'
 import Hero from '../components/Hero'
+import ResourceContainer from '../components/ResourceContainer'
+import Stats from '../components/Stats'
 // Typography
 import {
   Title1,
@@ -18,6 +20,8 @@ import {
 } from '../components/Typography';
 // Utility
 import fireDb from '../utilities/firebase';
+
+const SECTION_MARGIN = '10em auto'
 
 const AboutHeader = styled.div`
   display: flex;
@@ -76,7 +80,10 @@ export default function Home() {
       <Background>
         <NavBar/>
         <Hero />
-        <ContentContainer>
+        <ContentContainer
+          id="about"
+          margin={SECTION_MARGIN}
+        >
           <AboutHeader>
             <Title1
               color={activeTab === 'Who We Are' ? themeContext.colors.primary : themeContext.colors.tertiary}
@@ -112,17 +119,29 @@ export default function Home() {
               </div>
             </AboutSection>
             :
-            <Body>This second part still needs to be done</Body>
+            <Stats numHackathons={13} numProjects={280} prizesValue={'$110,230'} numWorkshops={50} donationsValue={'$5,075'} />
           }
         </ContentContainer>
-        <ContentContainer>
+        <ContentContainer
+          id="hackathons" 
+          margin={SECTION_MARGIN}
+        >
           <Title1 withGradient align="center">
             Hackathons
           </Title1>
           <Hackathons />
         </ContentContainer>
+        <ContentContainer
+          id="resources" 
+          margin={SECTION_MARGIN}
+        >
+          <ResourceContainer />
+        </ContentContainer>
         {faqs &&
-          <ContentContainer>
+          <ContentContainer
+            id="faq" 
+            margin={SECTION_MARGIN}
+          >
             <FaqSection>
               <Title1
                 withGradient

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -6,6 +6,7 @@ body {
   margin: 0;
   font-family: 'HK Grotesk', -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
     Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
+  scroll-behavior: smooth;
 }
 
 a {


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/hllwtNe9cnAeA/giphy.gif)

## Description
IT'S THE FINAL STRETCH. This just adds the Stats section and Resources section to the landing page. I refactored the `ContentContainer` component to take in `id` and `margin` props. `id` is used to set anchor link targets for the nav bar and `margin` is used to achieve the spacing between sections (as specified by the designs).

I set the right link targets for the nav bar and then called it a day. Smooth scrolling is supported.

### Navbar refactor
Noticed that there were two sort of bugs with the navbar:
1. Can't click through it even if it's invisible
2. Doesn't appear when you scroll up

The first problem was fixed by making the actual navbar container (ie. the one that has the `visibility` and `opacity` properties toggled) the root one of the component. Before the parent container was still "visible" and eating clicks, so you wouldn't be able to click anything on the page if it was where the navbar usually is.

The second problem I fixed by altering a bit of the `handleScroll` function. I just looked at what was done previously and it was a little different from our implementation so I just changed it to match. Now the navbar will appear on scroll up.

![image](https://user-images.githubusercontent.com/5078356/131422665-c10d1a80-e62a-4311-a575-9a444cd67f27.png)
![image](https://user-images.githubusercontent.com/5078356/131422674-a71726d1-9cb5-468d-bad4-368a83839235.png)