### PR TITLE
Remove exclamation mark from hyperlink text in Resources

### DIFF
--- a/components/ResourceContainer.js
+++ b/components/ResourceContainer.js
@@ -49,7 +49,8 @@ const FilterCardContainer = styled.div`
 const RESOURCES_TITLE = 'Resources';
 const RESOURCES_BODY = 'If you are looking to get started in Computer Science, check out our ';
 const RESOURCES_LINK = 'https://resources.nwplus.io/';
-const RESOURCES_LINK_TEXT = 'Self-Learning Resources Wiki!';
+const RESOURCES_LINK_TEXT = 'Self-Learning Resources Wiki';
+const EXCLAMATION_MARK = '!';
 
 export default function ResourceContainer() {
   const [typeFilters, setTypeFilters] = useState({
@@ -173,6 +174,7 @@ export default function ResourceContainer() {
           <a href={RESOURCES_LINK} target='_blank' rel="noreferrer">
             <LinkBody>{RESOURCES_LINK_TEXT}</LinkBody>
           </a>
+          {EXCLAMATION_MARK}
         </Body>
       </HeaderContainer>
       <CardContainer>      


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
Resolves #97 
Exclamation mark is no longer included in the hyperlink.
![image](https://user-images.githubusercontent.com/37602670/132963019-d37da99c-7711-4304-9312-c97325d5e972.png)


## Other considerations
<!--- Workarounds, planned future changes, special notes, etc. -->
