### PR TITLE
Use better YouTube thumbnail URLs

### DIFF
--- a/utils/ResourceUtils.js
+++ b/utils/ResourceUtils.js
@@ -44,7 +44,7 @@ export const RESOURCES = [
   {
     name: 'Web Dev for Dummies',
     year: '2020',
-    image: 'https://i.ytimg.com/vi/R7UxJMAVvLU/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLDWdHwEkVTw0mR8hmb0UwxMI0CcYQ',
+    image: 'https://img.youtube.com/vi/R7UxJMAVvLU/maxresdefault.jpg',
     badge: BADGE_ICON,
     type: ResourceType.VIDEO,
     link: 'https://www.youtube.com/watch?v=R7UxJMAVvLU'
@@ -53,7 +53,7 @@ export const RESOURCES = [
     name: 'Git the Basics Workshop',
     event: ResourceEvent.CMD_F,
     year: '2021',
-    image: 'https://i.ytimg.com/an_webp/BjJn4HW_-PI/mqdefault_6s.webp?du=3000&sqp=CNzBhIoG&rs=AOn4CLCKvA-rF5Obce1IYBVBmWEdozlo7Q',
+    image: 'https://img.youtube.com/vi/BjJn4HW_-PI/maxresdefault.jpg',
     badge: BADGE_ICON,
     type: ResourceType.VIDEO,
     link: 'https://www.youtube.com/watch?v=BjJn4HW_-PI'
@@ -61,7 +61,7 @@ export const RESOURCES = [
   {
     name: 'Technical Interview Workshop: Beginner Edition',
     year: '2020',
-    image: 'https://i.ytimg.com/vi/J7Goi2aF0uw/hqdefault.jpg?sqp=-oaymwEcCNACELwBSFXyq4qpAw4IARUAAIhCGAFwAcABBg==&rs=AOn4CLCqoUcsCe75F6Krxl_QUpx9hZeGWQ',
+    image: 'https://img.youtube.com/vi/J7Goi2aF0uw/maxresdefault.jpg',
     badge: BADGE_ICON,
     type: ResourceType.VIDEO,
     link: 'https://www.youtube.com/watch?v=J7Goi2aF0uw'


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
The thumbnail URLs for YouTube video resources weren't fetched the best way (in that I just right clicked -> `Copy Image URL` and then called it a day). As a result one of them broke, so now I've changed the URL to be more readable, higher res, and more robust.

Before:
![image](https://user-images.githubusercontent.com/5078356/133482063-22cc16ad-d8cf-4801-81ea-f7d32d99c7e0.png)

After:
![image](https://user-images.githubusercontent.com/5078356/133482090-d929e336-1c44-4c4b-b212-0a346738a7a5.png)