### PR TITLE
Mobile responsiveness for filters section

### DIFF
--- a/components/HackathonCard.js
+++ b/components/HackathonCard.js
@@ -15,12 +15,11 @@ const CardContainer = styled.div`
     position: relative;
 
     & > ${BackgroundImageContainer} {
-        background: ${p => p.theme.colors.shadedGradient}, url(${p => p.imageLink}) center;
-        background-size: cover;
+        background: ${p => p.theme.colors.shadedGradient}, url(${p => p.imageLink}) center/cover;
     }
 
     &:hover > ${BackgroundImageContainer} {
-        background: url(${p => p.imageLink}) center;
+        background: url(${p => p.imageLink}) center/cover;
         transform: scale(1.1);
     }
 `

--- a/components/HackathonCard.js
+++ b/components/HackathonCard.js
@@ -7,7 +7,7 @@ const BackgroundImageContainer = styled.div`
 `
 
 const CardContainer = styled.div`
-    width: 380px;
+    width: 100%;
     height: 500px;
     overflow: hidden;
     border-radius: 12px;
@@ -46,9 +46,14 @@ const OverLayFooterContainer = styled.div`
 const EventDataContainer = styled.div`
     width: 100%;
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
     font-size: 1.2em;
     font-weight: bold;
+
+    ${(p) => p.theme.mediaQueries.mobile} {
+        flex-direction: column;
+    }
 `
 
 const EventRegistrationStatus = styled.div`

--- a/components/ResourceContainer.js
+++ b/components/ResourceContainer.js
@@ -34,6 +34,7 @@ const FilterContainer = styled.div`
   ${(p) => p.theme.mediaQueries.mobile} {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     margin-bottom: 16px;
     margin-right: 0px;
   }
@@ -44,6 +45,7 @@ const FilterCardContainer = styled.div`
   flex-wrap: wrap-content;
   ${(p) => p.theme.mediaQueries.mobile} {
     margin-right: 10px;
+    flex-grow: 1;
   }
 `
 const RESOURCES_TITLE = 'Resources';

--- a/components/ResourcePage.js
+++ b/components/ResourcePage.js
@@ -18,7 +18,7 @@ const ResourcePageContainer = styled.div`
   row-gap: 56px;
   margin-bottom: 40px;
   ${(p) => p.theme.mediaQueries.mobile} {
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
     grid-template-rows: 1fr 1fr 1fr;
     column-gap: 28px;
     row-gap: 24px;


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/kLD4qwwxjxvDa/giphy.gif)

## Description
This will do a lot of the work to resolve #89, and @dchen150's PR #113 should close that!

### Resources section
Added a couple of flex properties to make the filters container flexible. Also realized that at some breakpoint we should make it one column of resources instead of two. The only thing I would flag is that the "Our Pick" badge isn't attached to its thumbnail at specific resolutions, but I think it's usable for the time being.

Before
![image](https://user-images.githubusercontent.com/5078356/133862384-7c5a54db-6726-49a1-8a35-24dcc05a99ac.png)

After
![image](https://user-images.githubusercontent.com/5078356/133862363-3ad14c9e-458e-4a27-9d39-caa28e56dc78.png)

### Hackathon cards
One of the containers for the cards had a static width, so I just changed that to `100%`. Then after that added some flex styling for the name + date section so that at smaller widths it looks good.

Before
![image](https://user-images.githubusercontent.com/5078356/133862910-877db25e-dc98-4f3d-8282-8a9ef89c15df.png)

After
![image](https://user-images.githubusercontent.com/5078356/133862885-7f32f5ec-0bb8-49d4-91ce-c0259986107d.png)
