### PR TITLE
Make carousel responsive

### DIFF
--- a/components/Carousel.js
+++ b/components/Carousel.js
@@ -10,7 +10,8 @@ const FlexBox = styled.div`
 
 const Container = styled.div`
     position: relative;
-    width: ${(p) => p.width}px;
+    height: ${(p) => p.height ? p.height : '100%'};
+    width: ${(p) => p.width ? p.width : '100%'};
 `
 
 const FilledDiamond = styled.div`
@@ -37,15 +38,11 @@ const EmptyDiamond = styled.div`
 `;
 
 const Image = styled.img`
-    width: 29vw;
-    height: 25hw;
+    height: 100%;
+    width: 100%;
     margin-bottom: 10px;
     border-radius: 6px;
     object-fit: cover;
-    ${(p) => p.theme.mediaQueries.mobile} {
-        width: ${(p) => p.width}px;
-        height: ${(p) => p.height}px;
-    }
 `;
 
 const BaseArrow = css`
@@ -89,10 +86,10 @@ export default function Carousel ({ images, height, width }) {
             {
                 numImages > 0
                 &&
-                <Container width={width}>
+                <Container width={width} height={height}>
                     <RightArrow onClick={() => setImageIndex(imageIndex == numImages - 1 ? 0 : imageIndex + 1)}/>
                     <LeftArrow onClick={() => setImageIndex(imageIndex == 0 ? numImages - 1 : imageIndex - 1)}/>
-                    <Image src={images[imageIndex]} width={width} height={height}/>
+                    <Image src={images[imageIndex]} />
                     <FlexBox>
                         {images.map((item, index) => {
                             return index == imageIndex

--- a/pages/index.js
+++ b/pages/index.js
@@ -49,10 +49,11 @@ const AboutSection = styled.div`
 `;
 
 const CarouselContainer = styled.div`
-  height: 50vh;
+  height: 400px;
   min-width: 40%;
 
   ${(p) => p.theme.mediaQueries.mobile} {
+    height: 250px;
     width: 100%;
   }
 `;

--- a/pages/index.js
+++ b/pages/index.js
@@ -40,11 +40,20 @@ const AboutSection = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 128px;
+  gap: 64px;
 
   ${(p) => p.theme.mediaQueries.mobile} {
     flex-direction: column;
     gap: 32px;
+  }
+`;
+
+const CarouselContainer = styled.div`
+  height: 50vh;
+  min-width: 40%;
+
+  ${(p) => p.theme.mediaQueries.mobile} {
+    width: 100%;
   }
 `;
 
@@ -104,19 +113,19 @@ export default function Home() {
           </AboutHeader>
           {activeTab === 'Who We Are' ?
             <AboutSection>
-              <Carousel
-                images={[
-                  '/assets/images/team_nwplus.png',
-                  '/assets/images/team_social_1.png',
-                  '/assets/images/team_hackcamp.png',
-                  '/assets/images/team_nwhacks.png',
-                  '/assets/images/team_social_2.png',
-                  '/assets/images/team_design.png',
-                  '/assets/images/team_dev.png'
-                ]}
-                height={363}
-                width={500}
-              />
+              <CarouselContainer>
+                <Carousel
+                  images={[
+                    '/assets/images/team_nwplus.png',
+                    '/assets/images/team_social_1.png',
+                    '/assets/images/team_hackcamp.png',
+                    '/assets/images/team_nwhacks.png',
+                    '/assets/images/team_social_2.png',
+                    '/assets/images/team_design.png',
+                    '/assets/images/team_dev.png'
+                  ]}
+                />
+              </CarouselContainer>
               <div>
                 <Title2 withGradient>nwPlus is a student-led club supporting aspiring programmers and designers, based out of University of British Columbia.</Title2>
                 <Body>Our mission: foster innovation and creativity in tech for students to connect with passionate peers and mentors, through events such as our annual hackathons. By providing the right tools, resources, and support, the team at nwPlus aims to encourage students to gain hands-on experience with cutting-edge technology outside of classroom settings.</Body>


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
Resolves #89. In desktop view the carousel will take up 40% of the viewport. In mobile view it will take up 100% (as it moves to its own row). Each view has a defined static height (I changed from using `50vh` since it was really weird on tall screens, and would be messed up on a vertical monitor).

Carousel still retains its ability to take a static height and width in case it needs to be used that way, but in this case it should depend on the parent containers to set that. The fallback (if a height and width aren't provided) is that the carousel takes up 100% width and 100% height of its parent container.

Before:
![image](https://user-images.githubusercontent.com/5078356/133940624-a165b995-af6c-4866-a6b1-e889553adbc6.png)

After:
![image](https://user-images.githubusercontent.com/5078356/133940613-03c38a39-1722-4ccc-8e6e-bd129351d1a4.png)

