### PR TITLE
Jasper/website copyright footer outdated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ When you create a pull request there will be a template that you can follow - th
 - as an author, be receptive to comments and feedback
 
 ### Reviewing pull requests 👀
-Pull requests require an approving review from a contributor with write access before they can pushed up to the main branch. If you're unsure of who you should ask for a review you can check the [CODEOWNERS](<!-- Link to CODEOWNERS file -->)file.
+Pull requests require an approving review from a contributor with write access before they can pushed up to the main branch. For more information, please reach out to the dev team.
 
 Reviewing is also a great way to learn about the codebase, learn what others are working on, and improve your own coding practices!
 

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -592,7 +592,7 @@ export default function Footer() {
           Become a Sponsor
         </a>
       </Links>
-      <div>Copyright &copy; 2024 nwPlus</div>
+      <div>Copyright &copy; {new Date().getFullYear()} nwPlus</div>
     </FooterContainer>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,6 +1485,54 @@
         }
       }
     },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.4.tgz",
+      "integrity": "sha512-jt8dMtIRWnJjRYLid6NWCxXzXdpr9VFT/vhDp8ioh+TtOR0UKPHMxei6R4GA3RqoyPEfFcSNmkG7OtyqCSxNIw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.4.tgz",
+      "integrity": "sha512-5i9tOQNO8kawwggHvQUVR3a5KzIGaE2dw1g1kL//z/N840djvGseHrJSFEGdP1c35gM+dSGPpAKHmeBKrwHM8g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.4.tgz",
+      "integrity": "sha512-QfVuXugxBkCUHN9yD/VZ1xqszcMlBDj6vrbRiQvmWuyNo39ON6HqGn3jDwVrTHc9oKo2a0XInm+0zEnQeDmjSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@next/swc-win32-x64-msvc": {
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-11.1.4.tgz",
@@ -14015,6 +14063,24 @@
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.4.tgz",
       "integrity": "sha512-jTme207yEV4On9Gk0QJYK2N3kfKVBx17lLOL3qSjqNbqk1TnE51xvzogOCQXNABbzQlBY+J/NN+eylPS4QOKwA==",
       "requires": {}
+    },
+    "@next/swc-darwin-arm64": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-11.1.4.tgz",
+      "integrity": "sha512-jt8dMtIRWnJjRYLid6NWCxXzXdpr9VFT/vhDp8ioh+TtOR0UKPHMxei6R4GA3RqoyPEfFcSNmkG7OtyqCSxNIw==",
+      "optional": true
+    },
+    "@next/swc-darwin-x64": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-11.1.4.tgz",
+      "integrity": "sha512-5i9tOQNO8kawwggHvQUVR3a5KzIGaE2dw1g1kL//z/N840djvGseHrJSFEGdP1c35gM+dSGPpAKHmeBKrwHM8g==",
+      "optional": true
+    },
+    "@next/swc-linux-x64-gnu": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-11.1.4.tgz",
+      "integrity": "sha512-QfVuXugxBkCUHN9yD/VZ1xqszcMlBDj6vrbRiQvmWuyNo39ON6HqGn3jDwVrTHc9oKo2a0XInm+0zEnQeDmjSw==",
+      "optional": true
     },
     "@next/swc-win32-x64-msvc": {
       "version": "11.1.4",


### PR DESCRIPTION
<!--- Add a GIF that describes how you feel about this PR (or just a cool one) -->
![](https://media.giphy.com/media/xuXzcHMkuwvf2/giphy.gif)

## Description
- updates the footer copyright text to use the current year dynamically instead of a hardcoded value

- includes resulting `package-lock.json` updates from reinstalling dependencies. (expected optional Next.js SWC platform packages; lockfile in sync for local development and builds)

- updated `CONTRIBUTING.md` to fix broken link and outdated info
